### PR TITLE
Changed to target .NET Standard 2.0 and added Values property to Requ…

### DIFF
--- a/src/RedHttpServer/RedHttpServer.csproj
+++ b/src/RedHttpServer/RedHttpServer.csproj
@@ -9,7 +9,7 @@
     <Description>Red is a http and websocket server framework built on asp.net core and kestrel. The API provided is inspired by express.js and designed to be simple and easy to use</Description>
     <Copyright>Copyright © Rosenbjerg 2018</Copyright>
     <AssemblyTitle>RedHttpServer</AssemblyTitle>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>RedHttpServer</AssemblyName>
     <PackageId>RHttpServer</PackageId>

--- a/src/RedHttpServer/RequestParameters.cs
+++ b/src/RedHttpServer/RequestParameters.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Red
 {
@@ -20,5 +22,7 @@ namespace Red
         /// </summary>
         /// <param name="paramId"></param>
         public string this[string paramId] => _ctx.GetRouteValue(paramId).ToString();
+
+        public Dictionary<string, string> Values => _ctx.GetRouteData().Values.ToDictionary(x => x.Key, x => x.Value?.ToString());       
     }
 }


### PR DESCRIPTION
This afternoon, I successfully wrapped your RedHttpServer to be used as the web server for Butterfly Server .NET (see https//butterflyserver.io); however, this required two changes...

- Targeting .NET Standard 2.0 instead of .NET Core 2.0
- Adding a Values property to your RequestParameters class

If you decide to accept these changes and update your NuGet package, I'll include RedHttpServer as a web server option for Butterfly Server .NET.